### PR TITLE
Add Button for Website Version Update

### DIFF
--- a/website/dev-dist/sw.js
+++ b/website/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ac6e1177'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.hpme9jeolc"
+    "revision": "0.al2a9l8i7bg"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/website/dev-dist/sw.js
+++ b/website/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ac6e1177'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.al2a9l8i7bg"
+    "revision": "0.nsp53doqkh8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
@@ -11,6 +11,7 @@ const SettingsUpdateButton = () => {
   /**
    * Clears all service workers and their caches.
    */
+  console.log("heeeereee")
   const clearServiceWorkers = () => {
     // Get all the registrations of the service workers and loop through them
     navigator.serviceWorker.getRegistrations().then((registrations) => {
@@ -20,7 +21,6 @@ const SettingsUpdateButton = () => {
       }
     });
     // Notify the user that the website has been updated
-    console.log("Website Updated");
     toast.success("Website Updated");
   };
   return (

--- a/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
@@ -2,7 +2,6 @@ import React from "react";
 
 const SettingsUpdateButton = () => {
   const clearServiceWorkers = () => {
-    console.log(navigator.onLine);
     navigator.serviceWorker.getRegistrations().then((registrations) => {
       for (const registration of registrations) {
         registration.unregister();

--- a/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React from "react";
 
-const SettingsUpdateCheck = () => {
+const SettingsUpdateButton = () => {
   const clearServiceWorkers = () => {
     console.log(navigator.onLine);
     navigator.serviceWorker.getRegistrations().then((registrations) => {
@@ -8,8 +8,6 @@ const SettingsUpdateCheck = () => {
         registration.unregister();
       }
     });
-
-    window.location.reload();
   };
   return (
     <>
@@ -47,4 +45,4 @@ const SettingsUpdateCheck = () => {
   );
 };
 
-export default SettingsUpdateCheck;
+export default SettingsUpdateButton;

--- a/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
@@ -1,17 +1,31 @@
 import React from "react";
 import { toast } from "react-toastify";
 
+/**
+ * A component for updating the website, deleting all service workers and their
+ * respective caches.
+ *
+ * @returns {JSX.Element} The rendered component.
+ */
 const SettingsUpdateButton = () => {
+  /**
+   * Clears all service workers and their caches.
+   */
   const clearServiceWorkers = () => {
+    // Get all the registrations of the service workers and loop through them
     navigator.serviceWorker.getRegistrations().then((registrations) => {
       for (const registration of registrations) {
+        // Unregister the service worker
         registration.unregister();
       }
     });
+    // Notify the user that the website has been updated
+    console.log("Website Updated");
     toast.success("Website Updated");
   };
   return (
     <>
+      {/* Container for the update button */}
       <div
         style={{
           width: "30dvw",
@@ -45,5 +59,6 @@ const SettingsUpdateButton = () => {
     </>
   );
 };
+
 
 export default SettingsUpdateButton;

--- a/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
@@ -11,7 +11,6 @@ const SettingsUpdateButton = () => {
   /**
    * Clears all service workers and their caches.
    */
-  console.log("heeeereee")
   const clearServiceWorkers = () => {
     // Get all the registrations of the service workers and loop through them
     navigator.serviceWorker.getRegistrations().then((registrations) => {

--- a/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateButton.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { toast } from "react-toastify";
 
 const SettingsUpdateButton = () => {
   const clearServiceWorkers = () => {
@@ -7,6 +8,7 @@ const SettingsUpdateButton = () => {
         registration.unregister();
       }
     });
+    toast.success("Website Updated");
   };
   return (
     <>

--- a/website/src/components/SettingsComponents/SettingsUpdateCheck.jsx
+++ b/website/src/components/SettingsComponents/SettingsUpdateCheck.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from "react";
+
+const SettingsUpdateCheck = () => {
+  const clearServiceWorkers = () => {
+    console.log(navigator.onLine);
+    navigator.serviceWorker.getRegistrations().then((registrations) => {
+      for (const registration of registrations) {
+        registration.unregister();
+      }
+    });
+
+    window.location.reload();
+  };
+  return (
+    <>
+      <div
+        style={{
+          width: "30dvw",
+          height: "17.84dvh",
+          position: "absolute",
+          top: "2.33dvh",
+          left: "50%",
+          transform: "translateX(-50%)",
+          backgroundColor: "#242424",
+          borderRadius: "3.49dvh",
+          border: "1.63dvh solid #1D1E1E",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          whiteSpace: "pre-wrap",
+          wordWrap: "break-word",
+        }}
+        onClick={clearServiceWorkers}
+      >
+        <h1
+          style={{
+            color: "#FFFFFF",
+            fontSize: "5.58dvh",
+            fontWeight: "bold",
+            textAlign: "center",
+          }}
+        >
+          Update Website
+        </h1>
+      </div>
+    </>
+  );
+};
+
+export default SettingsUpdateCheck;

--- a/website/src/pages/SettingsPage.jsx
+++ b/website/src/pages/SettingsPage.jsx
@@ -5,7 +5,7 @@ import ProceedBackButton from "../components/ProceedBackButton";
 import SettingsMatchDataScanner from "../components/SettingsComponents/SettingsMatchDataScanner";
 import SettingsButton from "../components/SettingsComponents/SettingsButton";
 import SettingsViewMatchData from "../components/SettingsComponents/SettingsViewMatchData";
-import SettingsUpdateCheck from "../components/SettingsComponents/SettingsUpdateCheck";
+import SettingsUpdateButton from "../components/SettingsComponents/SettingsUpdateButton";
 
 /**
  * A page for the user to access settings such as clearing match data, viewing match data, and getting match data.
@@ -109,7 +109,6 @@ const SettingsPage = () => {
               color: "#FFFFFF",
               fontSize: "5.58dvh",
               fontWeight: "bold",
-              
             }}
           >
             Back
@@ -125,7 +124,7 @@ const SettingsPage = () => {
           back={true}
         />
       )}
-      <SettingsUpdateCheck />
+      <SettingsUpdateButton />
     </>
   );
 };

--- a/website/src/pages/SettingsPage.jsx
+++ b/website/src/pages/SettingsPage.jsx
@@ -124,6 +124,7 @@ const SettingsPage = () => {
           back={true}
         />
       )}
+      {/* Render a button to update service workers */}
       <SettingsUpdateButton />
     </>
   );

--- a/website/src/pages/SettingsPage.jsx
+++ b/website/src/pages/SettingsPage.jsx
@@ -5,6 +5,7 @@ import ProceedBackButton from "../components/ProceedBackButton";
 import SettingsMatchDataScanner from "../components/SettingsComponents/SettingsMatchDataScanner";
 import SettingsButton from "../components/SettingsComponents/SettingsButton";
 import SettingsViewMatchData from "../components/SettingsComponents/SettingsViewMatchData";
+import SettingsUpdateCheck from "../components/SettingsComponents/SettingsUpdateCheck";
 
 /**
  * A page for the user to access settings such as clearing match data, viewing match data, and getting match data.
@@ -124,6 +125,7 @@ const SettingsPage = () => {
           back={true}
         />
       )}
+      <SettingsUpdateCheck />
     </>
   );
 };


### PR DESCRIPTION
This pull request adds a button to the website that clears the service workers, allowing users to update the website to the latest version without needing to manually clear their cache. 

Changes:
- Added a `Update Website` button to the UI in the Settings page
- Implemented functionality to unregister and reload service workers on click