### PR TITLE
Add Preload Option In Auto

### DIFF
--- a/website/dev-dist/sw.js
+++ b/website/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ac6e1177'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.331cf7bcmvg"
+    "revision": "0.ig7r1o7msfg"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/website/src/components/ScoringComponents/ScoringAlgae/ScoringAlgaeSection.jsx
+++ b/website/src/components/ScoringComponents/ScoringAlgae/ScoringAlgaeSection.jsx
@@ -41,7 +41,7 @@ const ScoringAlgaeSection = ({ pickData, placeData }) => {
       </div>
       <div style={{ width: "90%", height: "25%", marginBottom: "2dvh" }}>
         <ScoringPickup
-          pickPositions={pickData.map((singlePickData) => {return singlePickData.position})}
+          pickData={pickData}
           pickPositionSelected={pickPositionSelected}
           setPickPositionSelected={setPickPositionSelected}
           place={"Algae"}

--- a/website/src/components/ScoringComponents/ScoringCoral/ScoringCoralSection.jsx
+++ b/website/src/components/ScoringComponents/ScoringCoral/ScoringCoralSection.jsx
@@ -8,22 +8,8 @@ import { toast } from "react-toastify";
 const ScoringCoralSection = ({
   pickData,
   placeData,
-  mode,
-  coralPreloaded,
-  setCoralPreloaded,
 }) => {
   const [pickPositionSelected, setPickPositionSelected] = useState("");
-  const [hideAutoCoralPreload, setHideAutoCoralPreload] = useState(false)
-
-  useEffect(() => {
-    if (coralPreloaded) {
-      if (placeData.find((singlePlaceData) => singlePlaceData.count > 0)) {
-        setHideAutoCoralPreload(true)
-      } else {
-        setHideAutoCoralPreload(false)
-      }
-    }
-  }, [placeData]);
 
   return (
     <div
@@ -43,7 +29,7 @@ const ScoringCoralSection = ({
       <div
         style={{
           width: "90%",
-          height: "20%",
+          height: "8%",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
@@ -59,28 +45,6 @@ const ScoringCoralSection = ({
         >
           Coral
         </h1>
-        {mode == "auto" && hideAutoCoralPreload && (
-          <div
-            style={{
-              width: "25%",
-              height: "100%",
-              backgroundColor: coralPreloaded ? "#507144" : "#242424",
-              border: "1.63dvh solid #1D1E1E",
-              borderRadius: "2dvh",
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              alignSelf: "flex-end",
-            }}
-            onClick={() => setCoralPreloaded(!coralPreloaded)}
-          >
-            <h1
-              style={{ color: "white", fontSize: "3.25dvh", fontWeight: "700" }}
-            >
-              Preload
-            </h1>
-          </div>
-        )}
       </div>
 
       <div
@@ -98,11 +62,9 @@ const ScoringCoralSection = ({
           pickData={pickData}
         />
       </div>
-      <div style={{ width: "90%", height: "15%" }}>
+      <div style={{ width: "90%", height: "17%" }}>
         <ScoringPickup
-          pickPositions={pickData.map((singlePickData) => {
-            return singlePickData.position;
-          })}
+          pickData={pickData}
           pickPositionSelected={pickPositionSelected}
           setPickPositionSelected={setPickPositionSelected}
           place={"Coral"}

--- a/website/src/components/ScoringComponents/ScoringCoral/ScoringCoralSection.jsx
+++ b/website/src/components/ScoringComponents/ScoringCoral/ScoringCoralSection.jsx
@@ -5,8 +5,25 @@ import ScoringCoralPlaceMap from "./ScoringCoralPlaceMap";
 import ScoringPickup from "../ScoringPickup";
 import { toast } from "react-toastify";
 
-const ScoringCoralSection = ({ pickData, placeData }) => {
+const ScoringCoralSection = ({
+  pickData,
+  placeData,
+  mode,
+  coralPreloaded,
+  setCoralPreloaded,
+}) => {
   const [pickPositionSelected, setPickPositionSelected] = useState("");
+  const [hideAutoCoralPreload, setHideAutoCoralPreload] = useState(false)
+
+  useEffect(() => {
+    if (coralPreloaded) {
+      if (placeData.find((singlePlaceData) => singlePlaceData.count > 0)) {
+        setHideAutoCoralPreload(true)
+      } else {
+        setHideAutoCoralPreload(false)
+      }
+    }
+  }, [placeData]);
 
   return (
     <div
@@ -23,16 +40,49 @@ const ScoringCoralSection = ({ pickData, placeData }) => {
         alignItems: "center",
       }}
     >
-      <h1
+      <div
         style={{
-          color: "#FFFFFF",
-          fontSize: "5dvh",
-          fontWeight: "bold",
-          marginBottom: 0,
+          width: "90%",
+          height: "20%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
         }}
       >
-        Coral
-      </h1>
+        <h1
+          style={{
+            color: "#FFFFFF",
+            fontSize: "5dvh",
+            fontWeight: "bold",
+            marginBottom: 0,
+          }}
+        >
+          Coral
+        </h1>
+        {mode == "auto" && hideAutoCoralPreload && (
+          <div
+            style={{
+              width: "25%",
+              height: "100%",
+              backgroundColor: coralPreloaded ? "#507144" : "#242424",
+              border: "1.63dvh solid #1D1E1E",
+              borderRadius: "2dvh",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              alignSelf: "flex-end",
+            }}
+            onClick={() => setCoralPreloaded(!coralPreloaded)}
+          >
+            <h1
+              style={{ color: "white", fontSize: "3.25dvh", fontWeight: "700" }}
+            >
+              Preload
+            </h1>
+          </div>
+        )}
+      </div>
+
       <div
         style={{ width: "80%", height: "70%", marginBottom: "1.5dvh" }}
         onClick={() => {

--- a/website/src/components/ScoringComponents/ScoringPage.jsx
+++ b/website/src/components/ScoringComponents/ScoringPage.jsx
@@ -93,6 +93,9 @@ const ScoringPage = ({
   const [passedStartLine, setPassedStartLine] = useState(
     statePath?.passedStartLine || false
   );
+  const [coralPreloaded, setCoralPreloaded] = useState(
+    statePath?.coralPreloaded || true
+  );
 
   // State stack for undo functionality
   const [stateStack, setStateStack] = useState([]);
@@ -121,6 +124,8 @@ const ScoringPage = ({
           placeAlgaeNetShot,
           placeAlgaeProcessor,
           placeAlgaeDropMiss,
+
+          coralPreloaded,
         },
         ...pickCoralData.map((singleCoralData) => {
           return {
@@ -151,6 +156,7 @@ const ScoringPage = ({
     placeAlgaeNetShot,
     placeAlgaeProcessor,
     placeAlgaeDropMiss,
+    coralPreloaded
   ]);
 
   // Function to handle undo operation
@@ -181,6 +187,8 @@ const ScoringPage = ({
       setPlaceAlgaeDropMiss(previousState.placeAlgaeDropMiss);
       setPassedStartLine(previousState.passedStartLine);
       setStateStack([...stateStack]);
+
+      setCoralPreloaded(previousState.coralPreloaded)
     }
   };
 
@@ -288,6 +296,8 @@ const ScoringPage = ({
           <ScoringCoralSection
             pickData={pickCoralData}
             placeData={placeCoralData}
+            coralPreloaded={coralPreloaded}
+            setCoralPreloaded={setCoralPreloaded}
           />
         </div>
       </div>
@@ -306,28 +316,56 @@ const ScoringPage = ({
           style={{
             width: "100%",
             height: "35%",
-            backgroundColor: "red",
             display: "flex",
             flexDirection: "column",
             justifyContent: "center",
             alignItems: "center",
           }}
         >
-          {/* <h1
+          <div
             style={{
-              color: "#FFFFFF",
-              fontSize: "8dvh",
-              fontWeight: "bold",
-              backgroundColor: "blue",
+              width: "100%",
+              height: "25%",
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: "1.5dvw",
             }}
           >
-            {mode.charAt(0).toUpperCase() + mode.slice(1)}
-          </h1> */}
+            <h1
+              style={{
+                color: mode == "auto" ? "#EEE1B3" : "#00A6A6",
+                fontSize: "8dvh",
+                fontWeight: "900",
+              }}
+            >
+              ————
+            </h1>
+            <h1
+              style={{
+                color: "#FFFFFF",
+                fontSize: "8dvh",
+                fontWeight: "bold",
+              }}
+            >
+              {mode.charAt(0).toUpperCase() + mode.slice(1)}
+            </h1>
+            <h1
+              style={{
+                color: mode == "auto" ? "#EEE1B3" : "#00A6A6",
+                fontSize: "8dvh",
+                fontWeight: "900",
+              }}
+            >
+              ————
+            </h1>
+          </div>
 
           <div
             style={{
               width: "100%",
-              height: "55%",
+              height: "75%",
               display: "flex",
               flexDirection: "row",
               justifyContent: "center",
@@ -343,15 +381,15 @@ const ScoringPage = ({
                 height: "100%",
                 display: "flex",
                 flexDirection: "column",
-                justifyContent: "space-between",
+                justifyContent: "center",
                 alignItems: "center",
-                gap: "20%"
+                gap: "2.5dvh",
               }}
             >
               <div
                 style={{
                   width: "100%",
-                  height: "50%", // Adjust this line
+                  height: "50%",
                 }}
               >
                 <ProceedBackButton
@@ -386,7 +424,7 @@ const ScoringPage = ({
                           "Count"]: singleAlgaeData.count,
                         }))
                       ),
-                      ...(mode === "auto" && { passedStartLine }),
+                      ...(mode === "auto" && { passedStartLine, coralPreloaded}),
                     },
                   }}
                 />
@@ -394,7 +432,7 @@ const ScoringPage = ({
               <div
                 style={{
                   width: "100%",
-                  height: "50%", // Adjust this line
+                  height: "50%",
                   display: "flex",
                   justifyContent: "center",
                   alignItems: "center",

--- a/website/src/components/ScoringComponents/ScoringPage.jsx
+++ b/website/src/components/ScoringComponents/ScoringPage.jsx
@@ -296,8 +296,6 @@ const ScoringPage = ({
           <ScoringCoralSection
             pickData={pickCoralData}
             placeData={placeCoralData}
-            coralPreloaded={coralPreloaded}
-            setCoralPreloaded={setCoralPreloaded}
           />
         </div>
       </div>

--- a/website/src/components/ScoringComponents/ScoringPickup.jsx
+++ b/website/src/components/ScoringComponents/ScoringPickup.jsx
@@ -1,6 +1,11 @@
 import ScoringPickupButton from "./ScoringPickupButton";
 
-const ScoringPickup = ({ pickPositions, pickPositionSelected, setPickPositionSelected, place}) => {
+const ScoringPickup = ({
+  pickData,
+  pickPositionSelected,
+  setPickPositionSelected,
+  place,
+}) => {
   return (
     <div
       style={{
@@ -12,16 +17,21 @@ const ScoringPickup = ({ pickPositions, pickPositionSelected, setPickPositionSel
         gap: "1dvw",
       }}
     >
-      {pickPositions.map((position, index) => (
-        <div style={{ width: "100%", height: "100%", flex: 1 }} key={index}>
-          <ScoringPickupButton
-            position={position}
-            pickPositionSelected={pickPositionSelected}
-            setPickPositionSelected={setPickPositionSelected}
-            place={place}
-          />
-        </div>
-      ))}
+      {pickData.map((singlePickData, index) => {
+        if (!singlePickData.hide) {
+          return (
+            <div style={{ width: "100%", height: "100%", flex: 1 }} key={index}>
+              <ScoringPickupButton
+                position={singlePickData.position}
+                pickPositionSelected={pickPositionSelected}
+                setPickPositionSelected={setPickPositionSelected}
+                place={place}
+              />
+            </div>
+          );
+        }
+        return null;
+      })}
     </div>
   );
 };

--- a/website/src/pages/AutoScoringPage.jsx
+++ b/website/src/pages/AutoScoringPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 import ScoringPage from "../components/ScoringComponents/ScoringPage";
@@ -7,6 +7,9 @@ const AutoScoringPage = () => {
   const location = useLocation();
   const states = location.state;
 
+  const [pickPreloadCount, setPickPreloadCount] = useState(
+    states?.inputs?.auto?.coral?.preload || 0
+  );
   const [pickCoralStationCount, setPickCoralStationCount] = useState(
     states?.inputs?.auto?.coral?.pickStationCount || 0
   );
@@ -21,6 +24,12 @@ const AutoScoringPage = () => {
   );
 
   const pickCoralData = [
+    {
+      position: "Preload",
+      count: pickPreloadCount,
+      setCount: setPickPreloadCount,
+      hide: false,
+    },
     {
       position: "Station",
       count: pickCoralStationCount,
@@ -42,6 +51,15 @@ const AutoScoringPage = () => {
       setCount: setPickCoralMark3Count,
     },
   ];
+
+  useEffect(() => {
+    const preloadData = pickCoralData.find(
+      (singlePickCoralData) => singlePickCoralData.position == "Preload"
+    );
+    if (preloadData && preloadData.count >= 1) {
+      preloadData.hide = true;
+    }
+  }, [pickCoralData]);
 
   const [pickAlgaeReefCount, setPickAlgaeReefCount] = useState(
     states?.inputs?.auto?.algae?.pickReefCount || 0


### PR DESCRIPTION
This pull request adds a preload option in the auto page. The button will disappear when the preload is placed.

Here is what it looks when preload not placed:
![image](https://github.com/user-attachments/assets/d3b7c1d5-269d-4b75-9a31-d9b4603d7612)

And when the preload is placed:
![image](https://github.com/user-attachments/assets/f1613f30-2f1e-4348-b308-077a240490d0)

Other than the UI change, when exporting data, if the robot placed their preload can be seen in the `autoCoralPickPreloadCount` column in the form of 0 (not placed) or 1 (placed).