### PR TITLE
Fix Netlify SPA routing for client-side navigation

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -25,3 +25,9 @@
   to = "/docs/"
   status = 301
   force = true
+
+# SPA fallback: serve index.html for client-side routes (fixes reload on subpages)
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
This PR adds an SPA fallback to the Netlify configuration, so all client-side routes correctly serve index.html.

This fixes the issue where reloading or directly navigating to subpages (e.g. React Router routes) would result in a 404 on Netlify. Navigation across the app now works reliably on refresh and deep links.