### PR TITLE
Add Global Match Timer and Validation for Auto, Teleop, and Endgame Flows

### DIFF
--- a/website/src/components/MatchScouting/AutoScoringComponents/AutoPositionSelector.jsx
+++ b/website/src/components/MatchScouting/AutoScoringComponents/AutoPositionSelector.jsx
@@ -35,6 +35,7 @@ const AutoPositionSelector = ({
   robotPositions,
   setRobotPositions,
   showShotInfo,
+  timerStarted = false,
 }) => {
   const imageDivRef = useRef(null);
 
@@ -100,6 +101,11 @@ const AutoPositionSelector = ({
   // ---------------------------------------------------------------------------
 
   const handleClick = (event) => {
+    if (!timerStarted) {
+      toast.error("Start the timer before adding robot positions.");
+      return;
+    }
+
     if (!driveType) {
       toast.error("Drive type not specified.");
       return;

--- a/website/src/components/MatchScouting/AutoScoringComponents/AutoPositionSelector.jsx
+++ b/website/src/components/MatchScouting/AutoScoringComponents/AutoPositionSelector.jsx
@@ -101,6 +101,16 @@ const AutoPositionSelector = ({
   // ---------------------------------------------------------------------------
 
   const handleClick = (event) => {
+    const last =
+      robotPositions.length > 0
+        ? robotPositions[robotPositions.length - 1]
+        : null;
+
+    if (last && last.driveType === "Shot" && !last.shotInfo) {
+      toast.error("Complete the current shot's data before adding another position.");
+      return;
+    }
+
     if (!timerStarted) {
       toast.error("Start the timer before adding robot positions.");
       return;
@@ -137,11 +147,7 @@ const AutoPositionSelector = ({
     );
     const newPosition = { x: fieldX, y: fieldY };
 
-    const lastPos =
-      robotPositions.length > 0
-        ? robotPositions[robotPositions.length - 1]
-        : null;
-    if (isWithinPositionRange(newPosition, lastPos, POSITION_RANGE_METERS)) {
+    if (isWithinPositionRange(newPosition, last, POSITION_RANGE_METERS)) {
       console.log("Clicked too close to the last robot position");
       toast.error("Position is too close to the last robot placement.");
       return;

--- a/website/src/components/MatchScouting/EndgameScoringComponents/EndgamePageControlSection.jsx
+++ b/website/src/components/MatchScouting/EndgameScoringComponents/EndgamePageControlSection.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ProceedBackButton from "../../ProceedBackButton";
 
-const EndgamePageControlSection = ({ states, extraInputs }) => {
+const EndgamePageControlSection = ({ states, extraInputs, onSubmitClick = () => {} }) => {
   return (
     <div
       style={{
@@ -32,6 +32,7 @@ const EndgamePageControlSection = ({ states, extraInputs }) => {
             ...extraInputs,
           }}
           message={"Submit"}
+          onClick={onSubmitClick}
         />
       </div>
     </div>

--- a/website/src/components/PageControlSection.jsx
+++ b/website/src/components/PageControlSection.jsx
@@ -9,6 +9,8 @@ const PageControlSection = ({
   pageTitle,
   backPage,
   nextPage,
+  proceedOnClick = () => {},
+  proceedIsAlert = false,
 }) => {
   return (
     <div
@@ -119,6 +121,8 @@ const PageControlSection = ({
               ...(states?.inputs || {}),
               ...extraInputs,
             }}
+            onClick={proceedOnClick}
+            isAlert={proceedIsAlert}
           />
         </div>
       </div>

--- a/website/src/components/ProceedBackButton.jsx
+++ b/website/src/components/ProceedBackButton.jsx
@@ -34,6 +34,7 @@ const ProceedBackButton = ({
   stateKey = null,
   onClick = () => {},
   textSize = "5.58dvh",
+  isAlert = false,
 }) => {
   const navigate = useNavigateWithBase();
   const location = useLocation();
@@ -89,6 +90,7 @@ const ProceedBackButton = ({
           // reset history when done with scouting one match
           localStorage.setItem("autoHistory", "[]");
           localStorage.setItem("teleopHistory", "[]");
+          localStorage.removeItem("matchTimerStart");
           navigate(nextPage, {
             state: buildState({
               matchNumber: (parseInt(inputs.matchNumber) + 1).toString(),
@@ -133,6 +135,7 @@ const ProceedBackButton = ({
           // if the user leaves in the middle of the match, this will reset their history
           localStorage.setItem("autoHistory", "[]");
           localStorage.setItem("teleopHistory", "[]");
+          localStorage.removeItem("matchTimerStart");
           navigate(nextPage, { state: buildState(inputs) });
         } else {
           // If the next page is not the game start page, pass the inputs as props to the next page
@@ -150,8 +153,8 @@ const ProceedBackButton = ({
         style={{
           width: "100%",
           height: "100%",
-          border: "1.63dvh solid #1D1E1E",
-          backgroundColor: "#242424",
+          border: `1.63dvh solid ${isAlert && !back ? "#FF4C4C" : "#1D1E1E"}`,
+          backgroundColor: isAlert && !back ? "#7F0000" : "#242424",
           borderRadius: "3.49dvh",
           display: "flex",
           justifyContent: "center",

--- a/website/src/pages/MatchScouting/AutoScoringPage.jsx
+++ b/website/src/pages/MatchScouting/AutoScoringPage.jsx
@@ -135,6 +135,15 @@ const AutoScoringPage = () => {
       toast.error("Start the timer before proceeding.");
       return false;
     }
+
+    if (
+      robotPositions.length > 0 &&
+      robotPositions[robotPositions.length - 1].driveType === "Shot" &&
+      !robotPositions[robotPositions.length - 1].shotInfo
+    ) {
+      toast.error("Complete the current shot's data before proceeding.");
+      return false;
+    }
   };
 
   // function to handle state changes and push current state to stack

--- a/website/src/pages/MatchScouting/AutoScoringPage.jsx
+++ b/website/src/pages/MatchScouting/AutoScoringPage.jsx
@@ -6,6 +6,7 @@ import AutoPositionSelector from "../../components/MatchScouting/AutoScoringComp
 import { toast } from "react-toastify";
 import ShotInfoSection from "../../components/ShotInfoSection";
 import PageControlSection from "../../components/PageControlSection";
+import { useMatchTimer } from "../../utils/useMatchTimer";
 
 const AutoScoringPage = () => {
   const location = useLocation();
@@ -22,6 +23,41 @@ const AutoScoringPage = () => {
 
   const [hopperPercent, setHopperPercent] = useState("80%");
   const [shotsPercent, setShotsPercent] = useState("80%");
+  const [proceedBlinking, setProceedBlinking] = useState(false);
+  const [proceedBlinkOn, setProceedBlinkOn] = useState(false);
+
+  const { timerStarted, elapsedMs, elapsedSeconds, start } = useMatchTimer();
+  const currentTimeSeconds = () => Number(elapsedSeconds.toFixed(2));
+
+  // Wrapper around setRobotPositions to timestamp each new entry
+  const updateRobotPositions = (updater) => {
+    setRobotPositions((prev) => {
+      const next =
+        typeof updater === "function"
+          ? updater(prev)
+          : Array.isArray(updater)
+            ? updater
+            : prev;
+
+      if (!Array.isArray(next)) return prev;
+
+      const prevLen = prev.length;
+      const nextLen = next.length;
+
+      // If exactly one new position was added, stamp it with the current auto time
+      if (nextLen === prevLen + 1) {
+        const lastIndex = nextLen - 1;
+        const lastPos = next[lastIndex];
+
+        if (lastPos && lastPos.timeSeconds == null) {
+          const timeSeconds = currentTimeSeconds();
+          return [...next.slice(0, lastIndex), { ...lastPos, timeSeconds }];
+        }
+      }
+
+      return next;
+    });
+  };
 
   useEffect(() => {
     const savedStack = JSON.parse(localStorage.getItem("autoHistory") || "[]");
@@ -73,6 +109,34 @@ const AutoScoringPage = () => {
 
     setStateStack((prev) => [...prev, [...robotPositions]]);
   }, [robotPositions]);
+
+  // When timer passes 25 seconds, begin blinking the proceed button
+  useEffect(() => {
+    if (timerStarted && elapsedMs >= 25000 && !proceedBlinking) {
+      setProceedBlinking(true);
+    }
+  }, [timerStarted, elapsedMs, proceedBlinking]);
+
+  useEffect(() => {
+    if (!proceedBlinking) {
+      setProceedBlinkOn(false);
+      return;
+    }
+
+    const id = setInterval(() => {
+      setProceedBlinkOn((prev) => !prev);
+    }, 500);
+
+    return () => clearInterval(id);
+  }, [proceedBlinking]);
+
+  const handleBeforeProceed = () => {
+    if (!timerStarted) {
+      toast.error("Start the timer before proceeding.");
+      return false;
+    }
+  };
+
   // function to handle state changes and push current state to stack
   useEffect(() => {
     if (
@@ -98,8 +162,35 @@ const AutoScoringPage = () => {
         alignItems: "center",
         padding: "5dvh",
         gap: "5dvh",
+        position: "relative",
       }}
     >
+      <div
+        style={{
+          position: "absolute",
+          top: "2dvh",
+          right: "1.5dvw",
+          padding: "1dvh 1.5dvw",
+          borderRadius: "2dvh",
+          backgroundColor: "#242424",
+          border: "0.8dvh solid #1D1E1E",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minWidth: "7dvw",
+        }}
+      >
+        <span
+          style={{
+            color: "#FFFFFF",
+            fontSize: "3dvh",
+            fontWeight: "bold",
+            textAlign: "center",
+          }}
+        >
+          {currentTimeSeconds().toFixed(1)}s
+        </span>
+      </div>
       <div
         style={{
           width: "60%",
@@ -114,12 +205,76 @@ const AutoScoringPage = () => {
           alignItems: "center",
         }}
       >
-        <AutoPositionSelector
-          driveType={driveType}
-          robotPositions={robotPositions}
-          setRobotPositions={setRobotPositions}
-          showShotInfo={showShotInfo}
-        />
+        {!timerStarted ? (
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: "3dvh",
+            }}
+          >
+            <h2
+              style={{
+                color: "#FFFFFF",
+                fontSize: "5dvh",
+                fontWeight: "bold",
+                margin: 0,
+              }}
+            >
+              Start Autonomous
+            </h2>
+            <div
+              style={{
+                width: "70%",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                cursor: "pointer",
+                border: "1.63dvh solid #1D1E1E",
+                backgroundColor: "#242424",
+                borderRadius: "3.49dvh",
+                padding: "2dvh 0",
+              }}
+              onClick={start}
+            >
+              <h3
+                style={{
+                  color: "#FFFFFF",
+                  fontSize: "4dvh",
+                  fontWeight: "bold",
+                  textAlign: "center",
+                  margin: 0,
+                }}
+              >
+                Start Timer
+              </h3>
+            </div>
+            <p
+              style={{
+                color: "#CCCCCC",
+                fontSize: "2.5dvh",
+                textAlign: "center",
+                margin: 0,
+                maxWidth: "80%",
+              }}
+            >
+              Start the timer to begin placing auto robot positions and to
+              enable proceeding to the next page.
+            </p>
+          </div>
+        ) : (
+          <AutoPositionSelector
+            driveType={driveType}
+            robotPositions={robotPositions}
+            setRobotPositions={updateRobotPositions}
+            showShotInfo={showShotInfo}
+            timerStarted={timerStarted}
+          />
+        )}
       </div>
       <div
         style={{
@@ -142,6 +297,8 @@ const AutoScoringPage = () => {
           pageTitle={"Auto"}
           nextPage={"teleop-scoring"}
           backPage={"game-start"}
+          proceedOnClick={handleBeforeProceed}
+          proceedIsAlert={proceedBlinkOn}
         />
 
         {showShotInfo ? (
@@ -151,9 +308,11 @@ const AutoScoringPage = () => {
             shotsPercent={shotsPercent}
             setShotsPercent={setShotsPercent}
             submitOnClick={() => {
-              setRobotPositions((prev) => [
-                ...prev.slice(0, prev.length - 1),
-                {
+              setRobotPositions((prev) => {
+                if (prev.length === 0) return prev;
+
+                const last = prev[prev.length - 1];
+                const updatedLast = {
                   x: robotPositions[robotPositions.length - 1].x,
                   y: robotPositions[robotPositions.length - 1].y,
                   driveType: "Shot",
@@ -161,8 +320,11 @@ const AutoScoringPage = () => {
                     hopperPercent: hopperPercent,
                     shotsPercent: shotsPercent,
                   },
-                },
-              ]);
+                  timeSeconds: last.timeSeconds,
+                };
+
+                return [...prev.slice(0, prev.length - 1), updatedLast];
+              });
             }}
           />
         ) : (

--- a/website/src/pages/MatchScouting/EndgameScoringPage.jsx
+++ b/website/src/pages/MatchScouting/EndgameScoringPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { toast } from "react-toastify";
 
 import EndgamePageControlSection from "../../components/MatchScouting/EndgameScoringComponents/EndgamePageControlSection";
 import EndgameBrokenSection from "../../components/MatchScouting/EndgameScoringComponents/EndgameBrokenSection";
@@ -13,20 +14,20 @@ const EndgameScoringPage = () => {
 
   const [brokenDown, setBrokenDown] = useState(states?.inputs?.broken || false);
   const [brokenDownTime, setBrokenDownTime] = useState(
-    states?.inputs?.brokenDownTime || "",
+    states?.inputs?.brokenDownTime,
   );
 
   const [playedDefense, setPlayedDefense] = useState(
     states?.inputs?.playedDefense || false,
   );
   const [defenseTime, setDefenseTime] = useState(
-    states?.inputs?.defenseTime || "",
+    states?.inputs?.defenseTime,
   );
   const [defenseSkill, setDefenseSkill] = useState(
-    states?.inputs?.defenseSkill || "",
+    states?.inputs?.defenseSkill,
   );
   const [playedDefenseOn, setPlayedDefenseOn] = useState(
-    states?.inputs?.playedDefenseOn || 0,
+    states?.inputs?.playedDefenseOn,
   );
 
   useEffect(() => {
@@ -42,6 +43,42 @@ const EndgameScoringPage = () => {
       setPlayedDefenseOn(0);
     }
   }, [playedDefense]);
+
+  const handleBeforeSubmit = () => {
+    if (playedDefense) {
+      const defenseTimeMissing =
+        defenseTime === null || defenseTime === undefined || defenseTime === "";
+      const defenseSkillMissing =
+        defenseSkill === null ||
+        defenseSkill === undefined ||
+        defenseSkill === "";
+      const playedDefenseOnMissing =
+        playedDefenseOn === null ||
+        playedDefenseOn === undefined ||
+        playedDefenseOn === 0;
+
+      if (defenseTimeMissing || defenseSkillMissing || playedDefenseOnMissing) {
+        toast.error(
+          "Fill in defense time, skill, and target when defense is played before submitting.",
+        );
+        return false;
+      }
+    }
+
+    if (brokenDown) {
+      const brokenDownTimeMissing =
+        brokenDownTime === null ||
+        brokenDownTime === undefined ||
+        brokenDownTime === "";
+
+      if (brokenDownTimeMissing) {
+        toast.error(
+          "Fill in the time the robot broke down before submitting.",
+        );
+        return false;
+      }
+    }
+  };
 
   return (
     <div
@@ -113,6 +150,7 @@ const EndgameScoringPage = () => {
               defenseSkill,
               playedDefenseOn,
             }}
+            onSubmitClick={handleBeforeSubmit}
           />
         </div>
       </div>

--- a/website/src/pages/MatchScouting/TeleopScoringPage.jsx
+++ b/website/src/pages/MatchScouting/TeleopScoringPage.jsx
@@ -5,6 +5,7 @@ import { toast } from "react-toastify";
 import ShotInfoSection from "../../components/ShotInfoSection";
 import PageControlSection from "../../components/PageControlSection";
 import TeleopFuelSourceSection from "../../components/MatchScouting/TeleopScoringComponents/TeleopFuelSourceSection";
+import { useMatchTimer } from "../../utils/useMatchTimer";
 
 const TeleopScoringPage = () => {
   const location = useLocation();
@@ -19,6 +20,9 @@ const TeleopScoringPage = () => {
   const [fuelOptionSelected, setFuelOptionSelected] = useState("");
 
   const [fuelShotAndSourceInfo, setFuelShotAndSourceInfo] = useState([]);
+
+  const { timerStarted, elapsedSeconds, start: startTimer } = useMatchTimer();
+  const currentTimeSeconds = () => Number(elapsedSeconds.toFixed(2));
 
   useEffect(() => {
     const savedStack = JSON.parse(
@@ -83,8 +87,42 @@ const TeleopScoringPage = () => {
         alignItems: "center",
         padding: "5dvh",
         gap: "5dvh",
+        position: "relative",
       }}
     >
+      <div
+        style={{
+          position: "absolute",
+          top: "2dvh",
+          right: "1.5dvw",
+          padding: "1dvh 1.5dvw",
+          borderRadius: "2dvh",
+          backgroundColor: "#242424",
+          border: "0.8dvh solid #1D1E1E",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minWidth: "7dvw",
+          cursor: timerStarted ? "default" : "pointer",
+          opacity: timerStarted ? 1 : 0.9,
+        }}
+        onClick={() => {
+          if (!timerStarted) {
+            startTimer();
+          }
+        }}
+      >
+        <span
+          style={{
+            color: "#FFFFFF",
+            fontSize: "3dvh",
+            fontWeight: "bold",
+            textAlign: "center",
+          }}
+        >
+          {timerStarted ? `${currentTimeSeconds().toFixed(1)}s` : "Start Timer"}
+        </span>
+      </div>
       <div
         style={{
           width: "55%",
@@ -163,6 +201,11 @@ const TeleopScoringPage = () => {
             shotsPercent={shotsPercent}
             setShotsPercent={setShotsPercent}
             submitOnClick={() => {
+              if (!timerStarted) {
+                toast.error("Start the timer before logging teleop shots!");
+                return;
+              }
+              const timeSeconds = currentTimeSeconds();
               if (fuelOptionSelected === "" || fuelOptionSelected === null) {
                 toast.error("Please select a fuel source!");
                 return;
@@ -173,6 +216,7 @@ const TeleopScoringPage = () => {
                   source: fuelOptionSelected,
                   hopperPercent: hopperPercent,
                   shotsPercent: shotsPercent,
+                  timeSeconds,
                 },
               ]);
               setFuelOptionSelected("");

--- a/website/src/utils/useMatchTimer.js
+++ b/website/src/utils/useMatchTimer.js
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from "react";
+
+const MATCH_TIMER_KEY = "matchTimerStart";
+
+export function useMatchTimer() {
+  const [startTimestamp, setStartTimestamp] = useState(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const intervalRef = useRef(null);
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(MATCH_TIMER_KEY);
+    if (stored) {
+      const ts = parseInt(stored, 10);
+      if (!Number.isNaN(ts)) {
+        setStartTimestamp(ts);
+        setElapsedMs(Date.now() - ts);
+      }
+    }
+  }, []);
+
+  // Drive the ticking timer whenever we have a start timestamp
+  useEffect(() => {
+    if (!startTimestamp) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+
+    intervalRef.current = setInterval(() => {
+      setElapsedMs(Date.now() - startTimestamp);
+    }, 100);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [startTimestamp]);
+
+  const start = () => {
+    if (startTimestamp) return;
+    const now = Date.now();
+    setStartTimestamp(now);
+    setElapsedMs(0);
+    localStorage.setItem(MATCH_TIMER_KEY, String(now));
+  };
+
+  const reset = () => {
+    setStartTimestamp(null);
+    setElapsedMs(0);
+    localStorage.removeItem(MATCH_TIMER_KEY);
+  };
+
+  const elapsedSeconds = elapsedMs / 1000;
+
+  return {
+    timerStarted: !!startTimestamp,
+    elapsedMs,
+    elapsedSeconds,
+    start,
+    reset,
+  };
+}
+
+export function clearMatchTimerStorage() {
+  localStorage.removeItem(MATCH_TIMER_KEY);
+}
+


### PR DESCRIPTION
This pull request adds the following:
- Add a persistent, global match timer shared across Game Start, Auto, Teleop, and Endgame.
- Gate user actions in Auto, Teleop, and Endgame so data cannot be submitted or advanced until required fields are filled.
- Record timestamps for auto robot positions and teleop fuel shots, and visually surface the timer in the UI.

Here is a image of the auto page before starting the match.
<img width="1841" height="1063" alt="image" src="https://github.com/user-attachments/assets/5622b11c-a34e-4e80-8fbe-7bd4d07e0f91" />
