### PR TITLE
Add Image Flip In Auto Scoring Field Image

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -35,6 +35,8 @@ import SettingsScoutingTemplate from "./components/Settings/SettingsScoutingTemp
 import SettingsViewDataPage from "./pages/Settings/SettingsViewDataPage";
 import PitScoutingSettingsPage from "./pages/Settings/PitScoutingSettingsPage";
 import PitScoutingSettingsAssignTeamPage from "./pages/Settings/PitScoutingSettingsAssignTeamPage";
+import MatchScoutingSettingsPage from "./pages/Settings/MatchScoutingSettingsPage";
+import FlipFieldSettingsPage from "./pages/Settings/FlipFieldSettingsPage";
 
 function App() {
   const [windowSize, setWindowSize] = useState({
@@ -71,13 +73,34 @@ function App() {
       <Route path="parse-data" element={<ParseDataPage />} />
       <Route path="event-data" element={<EventDataSettingsPage />} />
       <Route path="event-data/load" element={<EventDataLoadChoicePage />} />
-      <Route path="event-data/load/online" element={<EventDataLoadOnlinePage />} />
-      <Route path="event-data/load/offline" element={<EventDataLoadOfflineChoicePage />} />
-      <Route path="event-data/load/offline/qrf" element={<EventDataLoadQRFPage />} />
-      <Route path="event-data/load/offline/file" element={<EventDataLoadFilePage />} />
-      <Route path="event-data/generate" element={<EventDataGenerateChoicePage />} />
-      <Route path="event-data/generate/qrf" element={<EventDataGenerateQRFPage />} />
-      <Route path="event-data/generate/file" element={<EventDataGenerateFilePage />} />
+      <Route
+        path="event-data/load/online"
+        element={<EventDataLoadOnlinePage />}
+      />
+      <Route
+        path="event-data/load/offline"
+        element={<EventDataLoadOfflineChoicePage />}
+      />
+      <Route
+        path="event-data/load/offline/qrf"
+        element={<EventDataLoadQRFPage />}
+      />
+      <Route
+        path="event-data/load/offline/file"
+        element={<EventDataLoadFilePage />}
+      />
+      <Route
+        path="event-data/generate"
+        element={<EventDataGenerateChoicePage />}
+      />
+      <Route
+        path="event-data/generate/qrf"
+        element={<EventDataGenerateQRFPage />}
+      />
+      <Route
+        path="event-data/generate/file"
+        element={<EventDataGenerateFilePage />}
+      />
       <Route path="team-number-prompt" element={<TeamNumberPromptPage />} />
       <Route
         path="pit-scouting/start-info"
@@ -91,36 +114,24 @@ function App() {
         path="pit-scouting/capabilities-page-two"
         element={<PitScoutingCapabilitiesPageTwo />}
       />
-      <Route
-        path="pit-scouting/photo"
-        element={<PitScoutingPhotoPage />}
-      />
+      <Route path="pit-scouting/photo" element={<PitScoutingPhotoPage />} />
       <Route
         path="settings/match-scouting"
-        element={
-          <SettingsScoutingTemplate
-            title="Match Scouting"
-            localStorageKey="scoutingData"
-          />
-        }
+        element={<MatchScoutingSettingsPage />}
+      />
+      <Route
+        path="settings/match-scouting/flip-field"
+        element={<FlipFieldSettingsPage />}
       />
       <Route
         path="settings/pit-scouting"
-        element={
-          <PitScoutingSettingsPage />
-        }
+        element={<PitScoutingSettingsPage />}
       />
       <Route
         path="settings/pit-scouting/assign-teams"
-        element={
-          <PitScoutingSettingsAssignTeamPage />
-        }
+        element={<PitScoutingSettingsAssignTeamPage />}
       />
-      <Route
-        path="settings/view-data"
-        element={<SettingsViewDataPage />}
-      />
-      
+      <Route path="settings/view-data" element={<SettingsViewDataPage />} />
     </Route>
   ));
 

--- a/website/src/components/MatchScouting/AutoScoringComponents/AutoPositionSelector.jsx
+++ b/website/src/components/MatchScouting/AutoScoringComponents/AutoPositionSelector.jsx
@@ -17,6 +17,7 @@ import RobotMarker, { ROBOT_SIZE } from "./RobotMarker.jsx";
 
 // Icons are in public/AutoScoringImages/ so they are always in dist (see RobotMarker.jsx).
 const AUTO_ICONS_BASE = `${import.meta.env.BASE_URL}AutoScoringImages`;
+const FLIP_FIELD_KEY = "flipField";
 
 // -----------------------------------------------------------------------------
 // Constants
@@ -36,8 +37,18 @@ const AutoPositionSelector = ({
   setRobotPositions,
   showShotInfo,
   timerStarted = false,
+  alliance,
 }) => {
   const imageDivRef = useRef(null);
+  const [flipField] = useState(() => {
+    if (typeof window === "undefined" || !window.localStorage) return false;
+    const stored = window.localStorage.getItem(FLIP_FIELD_KEY);
+    return stored !== null ? stored === "true" : false;
+  });
+
+  const applyVerticalFlip = !flipField;
+  const applyHorizontalFlip = !flipField;
+  const centerOnRight = alliance === "blueAlliance";
 
   const [imagePixelSize, setImagePixelSize] = useState({
     width: 0,
@@ -66,7 +77,7 @@ const AutoPositionSelector = ({
       const rect = div.getBoundingClientRect();
       const imageWidthPixels = rect.width * ((FIELD_WIDTH_PERCENT + 100) / 100);
       const imageHeightPixels = rect.height;
-      const offsetX = 0;
+      const offsetX = centerOnRight ? rect.width - imageWidthPixels : 0;
       const offsetY = (rect.height - imageHeightPixels) / 2;
 
       setImagePixelSize({ width: imageWidthPixels, height: imageHeightPixels });
@@ -77,7 +88,7 @@ const AutoPositionSelector = ({
     const resizeObserver = new ResizeObserver(updateSize);
     resizeObserver.observe(div);
     return () => resizeObserver.disconnect();
-  }, []);
+  }, [centerOnRight]);
 
   useEffect(() => {
     const lastIndex = robotPositions.length - 1;
@@ -107,7 +118,9 @@ const AutoPositionSelector = ({
         : null;
 
     if (last && last.driveType === "Shot" && !last.shotInfo) {
-      toast.error("Complete the current shot's data before adding another position.");
+      toast.error(
+        "Complete the current shot's data before adding another position.",
+      );
       return;
     }
 
@@ -135,13 +148,20 @@ const AutoPositionSelector = ({
       return;
     }
 
+    const canonicalImageX = applyHorizontalFlip
+      ? imagePixelSize.width - imageX
+      : imageX;
+    const canonicalImageY = applyVerticalFlip
+      ? imagePixelSize.height - imageY
+      : imageY;
+
     const fieldX = pixelsToMetersX(
-      imageX,
+      canonicalImageX,
       imagePixelSize.width,
       REAL_FIELD_SIZE.width,
     );
     const fieldY = pixelsToMetersY(
-      imageY,
+      canonicalImageY,
       imagePixelSize.height,
       REAL_FIELD_SIZE.height,
     );
@@ -176,6 +196,13 @@ const AutoPositionSelector = ({
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
+
+  const scaleX = applyHorizontalFlip ? -1 : 1;
+  const scaleY = applyVerticalFlip ? -1 : 1;
+  const fieldTransform =
+    scaleX === 1 && scaleY === 1
+      ? "none"
+      : `scaleX(${scaleX}) scaleY(${scaleY})`;
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -213,10 +240,12 @@ const AutoPositionSelector = ({
           height: "100%",
           backgroundImage: mapLoaded ? `url(${FullFieldMap})` : "none",
           backgroundRepeat: "no-repeat",
-          backgroundPosition: "left center",
+          backgroundPosition: centerOnRight ? "right center" : "left center",
           backgroundSize: `${FIELD_WIDTH_PERCENT + 100}% 100%`,
           cursor: "crosshair",
           borderRadius: "1.5dvh",
+          transform: fieldTransform,
+          transformOrigin: "center center",
           opacity: mapLoaded ? 1 : 0,
           transition: "opacity 0.15s ease-out",
         }}

--- a/website/src/pages/MatchScouting/AutoScoringPage.jsx
+++ b/website/src/pages/MatchScouting/AutoScoringPage.jsx
@@ -282,6 +282,7 @@ const AutoScoringPage = () => {
             setRobotPositions={updateRobotPositions}
             showShotInfo={showShotInfo}
             timerStarted={timerStarted}
+            alliance={states?.inputs?.alliance}
           />
         )}
       </div>

--- a/website/src/pages/Settings/FlipFieldSettingsPage.jsx
+++ b/website/src/pages/Settings/FlipFieldSettingsPage.jsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect } from "react";
+import ProceedBackButton from "../../components/ProceedBackButton";
+import ToggleButton from "../../components/ToggleButton";
+import FullFieldMapImg from "../../assets/FullFieldMap.png";
+
+const FLIP_FIELD_KEY = "flipField";
+
+const FlipFieldSettingsPage = () => {
+  const [flipField, setFlipField] = useState(() => {
+    const stored = localStorage.getItem(FLIP_FIELD_KEY);
+    return stored !== null ? stored === "true" : false;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(FLIP_FIELD_KEY, String(flipField));
+  }, [flipField]);
+
+  return (
+    <div
+      style={{
+        height: "100dvh",
+        width: "100dvw",
+        display: "flex",
+        flexDirection: "column",
+        padding: "2dvh 2dvw",
+        boxSizing: "border-box",
+      }}
+    >
+      <div
+        style={{
+          flex: "0 0 20dvh",
+          minHeight: "20dvh",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "2dvh 2dvw",
+          gap: "2dvw",
+        }}
+      >
+        <div
+          style={{
+            width: "15dvw",
+            height: "100%",
+            flexShrink: 0,
+          }}
+        >
+          <ProceedBackButton nextPage="settings/match-scouting" back={true} />
+        </div>
+        <h1
+          style={{
+            flex: 1,
+            color: "#FFFFFF",
+            fontSize: "8dvh",
+            fontWeight: "bold",
+            textAlign: "center",
+          }}
+        >
+          Flip Field
+        </h1>
+        <div style={{ width: "15dvw", minWidth: "15dvw", flexShrink: 0 }} />
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          gap: "2dvh",
+          overflow: "auto",
+          padding: "2dvh 8dvw",
+        }}
+      >
+        <p
+          style={{
+            color: "#FFFFFF",
+            fontSize: "4dvh",
+            margin: 0,
+            textAlign: "center",
+          }}
+        >
+          Are you facing the correct way based on the map below? Look at the
+          outpost and depot positions to confirm your orientation.
+        </p>
+        <div
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "row",
+            gap: "2dvw",
+            alignItems: "stretch",
+          }}
+        >
+          <div
+            style={{
+              flex: 1,
+              minWidth: 0,
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <img
+              src={FullFieldMapImg}
+              alt="Full field map - Red left, Blue right, central depot, outposts at far ends"
+              style={{
+                maxWidth: "100%",
+                maxHeight: "50dvh",
+                objectFit: "contain",
+                borderRadius: "1dvh",
+                transform: flipField ? "none" : "scaleX(-1)",
+              }}
+            />
+          </div>
+          <div
+            style={{
+              flex: "0 0 auto",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ width: "100%", height: "50%" }}>
+              <ToggleButton
+                question={"Flip Field"}
+                selected={!flipField}
+                setSelected={() => setFlipField(!flipField)}
+                fontSize="5dvh"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FlipFieldSettingsPage;

--- a/website/src/pages/Settings/MatchScoutingSettingsPage.jsx
+++ b/website/src/pages/Settings/MatchScoutingSettingsPage.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import SettingsScoutingTemplate from "../../components/Settings/SettingsScoutingTemplate";
+import ProceedBackButton from "../../components/ProceedBackButton";
+
+const MatchScoutingSettingsPage = () => {
+  return (
+    <SettingsScoutingTemplate
+      title="Match Scouting"
+      localStorageKey="scoutingData"
+    >
+      <div style={{ width: "50%", height: "100%" }}>
+        <ProceedBackButton
+          nextPage="settings/match-scouting/flip-field"
+          message="Flip Field"
+        />
+      </div>
+    </SettingsScoutingTemplate>
+  );
+};
+
+export default MatchScoutingSettingsPage;


### PR DESCRIPTION
This pull request adds functionality to flip the auto scoring page image based on where the scouter is standing relative to the field. This will make scouting the auto routines more accurate and less confusing for the scouters. Additionally, this fixes a bug where the image does not switch if the alliance is changed.

To change the orientation for a device, the option can be found in the match scouting settings under "Flip Field".
<img width="1846" height="1066" alt="image" src="https://github.com/user-attachments/assets/f35cc53c-5ae2-4b8a-a92d-7563b2a2fb2a" />
